### PR TITLE
Consolidate dependency updates from Renovate dashboard

### DIFF
--- a/.github/actions/setup-cookiecutter-template/action.yaml
+++ b/.github/actions/setup-cookiecutter-template/action.yaml
@@ -14,7 +14,7 @@ runs:
 
   steps:
     - name: Set up python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
 

--- a/.github/workflows/build-dotnet-pipeline.yaml
+++ b/.github/workflows/build-dotnet-pipeline.yaml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Cookiecutter Template
         uses: ./.github/actions/setup-cookiecutter-template
@@ -39,7 +39,7 @@ jobs:
           template-cloud-service: ${{ matrix.cloud-service }}
 
       - name: Setup dotnet ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
 

--- a/.github/workflows/build-python-pipeline.yaml
+++ b/.github/workflows/build-python-pipeline.yaml
@@ -27,12 +27,12 @@ jobs:
           - "Azure Function App"
           - "GCP Cloud Function"
         python-version:
-          - "3.10"
-          - "3.11"
+          - "3.12"
+          - "3.13"
       fail-fast: false
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Cookiecutter Template
         uses: ./.github/actions/setup-cookiecutter-template
@@ -41,7 +41,7 @@ jobs:
           template-cloud-service: ${{ matrix.cloud-service }}
 
       - name: Set up python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.cloud-service }}-${{ hashFiles('**/pyproject.toml') }}

--- a/.github/workflows/build-typescript-pipeline.yaml
+++ b/.github/workflows/build-typescript-pipeline.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Cookiecutter Template
         uses: ./.github/actions/setup-cookiecutter-template
@@ -40,7 +40,7 @@ jobs:
           template-cloud-service: ${{ matrix.cloud-service }}
 
       - name: Setup Node ${{ matrix.node-version }} Environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@
 [![](https://img.shields.io/badge/made%20using%20cookiecutter-grey?style=for-the-badge&logo=cookiecutter)](https://github.com/cookiecutter/cookiecutter)
 
 
-This is a modern 🍪 Cookiecutter template to create REST APIs for multiple cloud platforms in multiple languages. This template supports the multiple cloud platforms and languages.
+A [Cookiecutter](https://github.com/cookiecutter/cookiecutter) template for generating REST APIs across multiple cloud platforms and languages.
 
-## 🧪 Usage
+## Usage
 
-Install Cookiecutter using pip package manager:
+Install Cookiecutter using pip:
 
 ```console
 # pipx is strongly recommended.
@@ -30,7 +30,7 @@ pipx install cookiecutter
 python -m pip install --user cookiecutter
 ```
 
-To create a Cookiecutter API project, run the following for each implemented template.
+Then generate a project from one of the available templates:
 
 ```console
 # Create using the GH CLI
@@ -40,9 +40,9 @@ cookiecutter gh:Code-and-Sorts/cookiecutter-api/{LANGUAGE_OPTION}
 cookiecutter https://github.com/Code-and-Sorts/cookiecutter-api.git --directory {LANGUAGE_OPTION}
 ```
 
-Follow the prompts and answer them with your own desired options.
+Follow the prompts to configure your project.
 
-## 🌟 Supported Templates
+## Supported Templates
 
 <table width="100%">
   <tr>
@@ -86,7 +86,7 @@ Follow the prompts and answer them with your own desired options.
 > [!NOTE]
 > Each project follows the controller-service-repository pattern.
 
-## 🎯 Examples
+## Examples
 
 Python
 - [Function App Example](https://github.com/Code-and-Sorts/cookie-py-az-func-api)
@@ -97,9 +97,9 @@ Typescript
 Dotnet
 - [Function App Example](https://github.com/Code-and-Sorts/cookie-cs-az-func-api)
 
-## 📚 Resources
+## Resources
 
-Below is a list of resources and documentation for the types of SDKs and frameworks used in the various Cookiecutter APIs.
+Below are the SDKs and frameworks used in the various templates.
 
 ### Python
 - [Poetry](https://python-poetry.org/) for dependency management
@@ -109,15 +109,15 @@ Below is a list of resources and documentation for the types of SDKs and framewo
 ### Typescript NodeJS
 - [Yarn](https://yarnpkg.com/) for dependency management
 - [Jest](https://jestjs.io/) for testing
-- [Zod](https://zod.dev/) for schema validtion
+- [Zod](https://zod.dev/) for schema validation
 
 ## Dotnet
 - [Nuget](https://www.nuget.org/) for dependency management
 - [xUnit](https://xunit.net/) for testing
-- [FluentValidation](https://docs.fluentvalidation.net/en/latest/) for schema validtion
+- [FluentValidation](https://docs.fluentvalidation.net/en/latest/) for schema validation
 
 ### Azure
-- [Azure Function Apps ](https://learn.microsoft.com/en-us/azure/azure-functions/) for hosting the APIs
+- [Azure Function Apps](https://learn.microsoft.com/en-us/azure/azure-functions/) for hosting the APIs
 - [Cosmos DB](https://learn.microsoft.com/en-us/azure/cosmos-db/) for data storage
 
 ### AWS
@@ -128,6 +128,6 @@ Below is a list of resources and documentation for the types of SDKs and framewo
 - [Cloud Functions](https://cloud.google.com/functions/docs) for hosting the APIs
 - [Firestore](https://cloud.google.com/firestore#documentation) for data storage
 
-## 🙏🏻 Acknowledgements
+## Acknowledgements
 
-Florian Maas' [cookiecutter-poetry](https://github.com/fpgmaas/cookiecutter-poetry) repository was a very helpful resource for building out this Cookiecutter template.
+Florian Maas' [cookiecutter-poetry](https://github.com/fpgmaas/cookiecutter-poetry) repository was a helpful resource for building out this template.

--- a/dotnet/{{cookiecutter.project_class_name}}/{{cookiecutter.project_class_name}}.Api.Tests.Unit/{{cookiecutter.project_class_name}}.Api.Tests.Unit.csproj
+++ b/dotnet/{{cookiecutter.project_class_name}}/{{cookiecutter.project_class_name}}.Api.Tests.Unit/{{cookiecutter.project_class_name}}.Api.Tests.Unit.csproj
@@ -3,14 +3,14 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.11.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
+    <PackageReference Include="FluentValidation" Version="12.0.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/dotnet/{{cookiecutter.project_class_name}}/{{cookiecutter.project_class_name}}.Api/{{cookiecutter.project_class_name}}.Api.csproj
+++ b/dotnet/{{cookiecutter.project_class_name}}/{{cookiecutter.project_class_name}}.Api/{{cookiecutter.project_class_name}}.Api.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="FluentValidation" Version="11.11.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <PackageReference Include="FluentValidation" Version="12.0.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore"
-      Version="2.0.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+      Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/python/{{cookiecutter.project_class_name}}/pyproject.toml
+++ b/python/{{cookiecutter.project_class_name}}/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 package-mode = false
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
+python = ">=3.10,<3.15"
 {% if cookiecutter.cloud_service == 'Azure Function App' -%}
 azure-cosmos = "^4.7.0"
 {%- endif %}
@@ -16,14 +16,14 @@ google-cloud-firestore = "^2.16.0"
 functions-framework = "^3.5.0"
 {%- endif %}
 pytest-mock = "^3.14.0"
-pytest-describe = "^2.2.0"
+pytest-describe = "^3.0.0"
 
 [tool.poetry.group.dev.dependencies]
 {% if cookiecutter.cloud_service == 'Azure Function App' -%}
-azure-functions = "1.20.0"
+azure-functions = "1.24.0"
 {%- endif %}
-pytest = "^8.3.2"
-pytest-cov = "^5.0.0"
+pytest = "^9.0.0"
+pytest-cov = "^7.0.0"
 pydantic = "^2.8.2"
 
 [build-system]

--- a/typescript/{{cookiecutter.project_class_name}}/package.json
+++ b/typescript/{{cookiecutter.project_class_name}}/package.json
@@ -2,7 +2,7 @@
   "name": "{{cookiecutter.project_endpoint}}",
   "version": "1.0.0",
   "description": "{{cookiecutter.project_description}}",
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.13.0",
   "main": "dist/functions/*.js",
   "scripts": {
     "build": "rm -rf dist && tsc && tsc-alias",
@@ -12,7 +12,7 @@
   "dependencies": {
     "@azure/cosmos": "^4.2.0",
     "@azure/functions": "^4.6.0",
-    "dotenv": "^16.4.5",
+    "dotenv": "^17.0.0",
     "inversify": "^6.1.4",
     "reflect-metadata": "^0.2.2",
     "uuid": "^11.0.3",
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/node": "^22.9.1",
+    "@types/node": "^24.0.0",
     "azure-functions-core-tools": "^4.x",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",


### PR DESCRIPTION
Updates all dependencies from the Renovate Dependency Dashboard (issue #12),
including the 3 open PRs (#30, #32, #33) and rate-limited updates.

Python:
- python >=3.10,<3.15 (was >=3.9,<3.13)
- azure-functions 1.24.0, pytest ^9.0.0, pytest-cov ^7.0.0, pytest-describe ^3.0.0
- CI matrix updated to Python 3.12, 3.13

TypeScript:
- yarn 4.13.0, dotenv ^17.0.0, @types/node ^24.0.0

.NET:
- FluentValidation 12.0.0, Microsoft.Azure.Cosmos 3.58.0
- Functions.Worker 2.51.0, .Extensions.Http.AspNetCore 2.1.0, .Sdk 2.0.7
- Newtonsoft.Json 13.0.4, Microsoft.NET.Test.Sdk 18.0.0
- xunit.runner.visualstudio 3.1.5

GitHub Actions:
- actions/checkout v6, actions/cache v5, actions/setup-python v6
- actions/setup-node v6, actions/setup-dotnet v5

README:
- Remove emoji prefixes from section headers
- Fix typos, tighten language

Skipped updates requiring breaking template changes:
- inversify 8, zod 4, typescript 6 (require moduleResolution changes)
- jest 30 / ts-jest 30 (ts-jest doesn't support jest 30 yet)
- uuid 13 (ESM-only, incompatible with CommonJS jest setup)
- azure-functions 2.0 (requires Python >=3.13)

https://claude.ai/code/session_012E7F8x6YrLyyHvuLYUixqo