### PR TITLE
Implement GCP Cloud Function support for TypeScript template

### DIFF
--- a/.github/workflows/build-typescript-pipeline.yaml
+++ b/.github/workflows/build-typescript-pipeline.yaml
@@ -25,6 +25,7 @@ jobs:
           - typescript
         cloud-service:
           - "Azure Function App"
+          - "GCP Cloud Function"
         node-version:
           - "18.x"
           - "20.x"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,146 @@
+# AGENTS.md
+
+Guidelines for AI agents working on the Cookiecutter API repository.
+
+## Project Overview
+
+This is a [Cookiecutter](https://github.com/cookiecutter/cookiecutter) template repository that generates REST API projects across multiple languages and cloud platforms. Each generated project follows the **controller-service-repository** pattern with full CRUD operations.
+
+## Repository Structure
+
+```
+cookiecutter-api/
+├── python/                  # Python template (Azure + GCP)
+├── typescript/              # TypeScript/Node.js template (Azure + GCP)
+├── dotnet/                  # .NET/C# template (Azure only)
+├── .github/
+│   ├── actions/             # Shared composite actions
+│   └── workflows/           # CI pipelines per language
+├── .docs/                   # Documentation assets (images, SVGs)
+└── README.md                # Support matrix and usage docs
+```
+
+Each language directory contains:
+- `cookiecutter.json` — Template variables and cloud service options
+- `hooks/` — Pre/post generation scripts (Python)
+- `{{cookiecutter.project_class_name}}/` — The template project root
+
+## Template Architecture
+
+All templates follow this layered architecture:
+
+```
+Entry Point (functions/ or main.ts/main.py)
+  → Controller (request validation, routing)
+    → Service (business logic, schema validation)
+      → Repository (database operations)
+        → Database (Cosmos DB or Firestore)
+```
+
+### Key Patterns
+
+- **Dependency Injection**: TypeScript uses [Inversify](https://inversify.io/), Python uses manual wiring in the blueprint/entry point
+- **Schema Validation**: TypeScript uses [Zod](https://zod.dev/), Python uses [Pydantic](https://docs.pydantic.dev/), .NET uses [FluentValidation](https://docs.fluentvalidation.net/)
+- **Soft Deletes**: All templates use an `isDeleted` flag rather than hard deletes
+- **Base Records**: All entities extend a base schema with `id`, `isDeleted`, `createdTimestamp`, `updatedTimestamp`
+
+## Multi-Cloud Support
+
+Cloud-specific code is handled through:
+
+1. **Jinja2 conditionals** — `{% if cookiecutter.cloud_service == '...' %}` blocks within shared files (repositories, configs, package manifests)
+2. **Separate entry point files** — Each cloud has its own entry point (e.g., `functions/*.ts` for Azure, `main.ts` for GCP)
+3. **Post-generation hooks** — `hooks/post_gen_project.py` removes files not needed for the selected cloud service
+
+### Cloud → Database Mapping
+
+| Cloud Provider | Database | TypeScript Client | Python Client |
+|---|---|---|---|
+| Azure Function App | Cosmos DB | `@azure/cosmos` | `azure-cosmos` |
+| GCP Cloud Function | Firestore | `@google-cloud/firestore` | `google-cloud-firestore` |
+
+## Adding a New Cloud Provider
+
+To add a new cloud provider (e.g., AWS Lambda) to an existing language template:
+
+1. **Update `cookiecutter.json`** — Add the new option to the `cloud_service` array
+2. **Create the entry point** — Add the cloud-specific function entry point file(s)
+3. **Add Jinja2 conditionals** to these files:
+   - `package.json` / `pyproject.toml` / `.csproj` — Cloud-specific dependencies
+   - `repositories/base.repository` — Database client implementation
+   - `repositories/{project}.repository` — DI binding for the database client
+   - `config/inversity.config.ts` (TypeScript) or blueprint wiring (Python) — DI container setup
+   - `types/models/baseEnv.schema` — Environment variable definitions
+4. **Update `hooks/post_gen_project.py`** — Add cleanup rules for the new cloud's files
+5. **Update CI pipeline** — Add the new cloud service to the `cloud-service` matrix in the workflow YAML
+6. **Update `README.md`** — Change the support table cell from planned to complete
+
+## Adding a New Language
+
+1. Create a new top-level directory (e.g., `go/`)
+2. Add `cookiecutter.json` with the standard variables (`project_name`, `project_endpoint`, `project_class_name`, `cloud_service`, etc.)
+3. Implement the controller-service-repository pattern in the target language
+4. Add `hooks/pre_gen_project.py` for input validation
+5. Add `hooks/post_gen_project.py` if supporting multiple cloud providers
+6. Create `.github/workflows/build-{language}-pipeline.yaml`
+7. Update the root `README.md` support table
+
+## Cookiecutter Variables
+
+| Variable | Description | Example |
+|---|---|---|
+| `project_name` | Human-readable name | `"My API"` |
+| `project_endpoint` | REST endpoint (kebab-case) | `"my-api"` |
+| `project_class_name` | PascalCase class name | `"MyApi"` |
+| `project_lower_camel_name` | lowerCamelCase (TS/C#) | `"myApi"` |
+| `project_slug` | snake_case (Python only) | `"my_api"` |
+| `cloud_service` | Target cloud platform | `"Azure Function App"` |
+| `author` | Project author | `"Your Name"` |
+| `open_source_license` | License type | `"MIT license"` |
+
+The `jinja2_strcase` extension provides `to_camel` and `to_lower_camel` filters for automatic case conversion.
+
+## Testing
+
+### CI Pipelines
+
+Each language has a GitHub Actions workflow that:
+1. Sets up Cookiecutter and generates a project with `--no-input`
+2. Installs dependencies
+3. Builds the project
+4. Runs unit tests
+
+The shared composite action at `.github/actions/setup-cookiecutter-template/action.yaml` handles steps 1-2.
+
+Pipelines use a matrix strategy to test across:
+- Multiple operating systems (ubuntu, macOS, Windows)
+- Multiple runtime versions (Node 18/20, Python 3.12/3.13)
+- All supported cloud services
+
+### Local Verification
+
+To verify changes locally, generate a template and test it:
+
+```bash
+# Install dependencies
+pip install cookiecutter jinja2-strcase
+
+# Generate a project
+cookiecutter ./typescript --no-input \
+  project_name="TestProject" \
+  cloud_service="GCP Cloud Function"
+
+# Build and test
+cd TestProject
+yarn install --no-immutable
+yarn build
+yarn test:unit
+```
+
+## Code Conventions
+
+- **TypeScript**: Yarn for packages, Jest for tests, path aliases (`@controllers`, `@services`, etc.) via `tsconfig.json` paths
+- **Python**: Poetry for packages, pytest for tests, blueprint pattern for route registration
+- **.NET**: NuGet for packages, xUnit for tests, solution/project structure
+- Template files use `{{cookiecutter.variable_name}}` in both filenames and content
+- Keep controllers, services, and error types cloud-agnostic — only repositories and entry points should contain cloud-specific code

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Follow the prompts to configure your project.
     <td align="center"><img src="./.docs/imgs/typescript.svg" height="18" title="NodeJS"></td>
     <td align="center"><span title="Complete">✅</span></td>
     <td align="center"><span title="Planned">📋</span></td>
-    <td align="center"><span title="Planned">📋</span></td>
+    <td align="center"><span title="Complete">✅</span></td>
   </tr>
   <tr>
     <td align="center"><img src="./.docs/imgs/dotnet.svg" height="18" title="dotnet"></td>

--- a/typescript/cookiecutter.json
+++ b/typescript/cookiecutter.json
@@ -6,7 +6,8 @@
     "project_class_name": "{{cookiecutter.project_name | to_camel }}",
     "author": "Code and Sorts (Colby Timm)",
     "cloud_service": [
-        "Azure Function App"
+        "Azure Function App",
+        "GCP Cloud Function"
     ],
     "open_source_license": [
         "MIT license",

--- a/typescript/hooks/post_gen_project.py
+++ b/typescript/hooks/post_gen_project.py
@@ -1,0 +1,30 @@
+"""Post-generation hook to clean up files based on cloud service selection."""
+import os
+import shutil
+
+cloud_service = "{{cookiecutter.cloud_service}}"
+
+# Files to remove based on cloud service
+if cloud_service == "Azure Function App":
+    # Remove GCP-specific files
+    files_to_remove = [
+        "main.ts",
+    ]
+elif cloud_service == "GCP Cloud Function":
+    # Remove Azure-specific files
+    files_to_remove = [
+        "host.json",
+        "local.settings.json",
+    ]
+    # Remove Azure Functions directory
+    if os.path.exists("functions"):
+        shutil.rmtree("functions")
+        print(f"Removed functions/ directory (not needed for {cloud_service})")
+else:
+    files_to_remove = []
+
+# Remove the files
+for file_path in files_to_remove:
+    if os.path.exists(file_path):
+        os.remove(file_path)
+        print(f"Removed {file_path} (not needed for {cloud_service})")

--- a/typescript/{{cookiecutter.project_class_name}}/config/inversity.config.ts
+++ b/typescript/{{cookiecutter.project_class_name}}/config/inversity.config.ts
@@ -1,21 +1,38 @@
 import "reflect-metadata";
 import { Container } from 'inversify';
+{% if cookiecutter.cloud_service == 'Azure Function App' -%}
 import { CosmosClient } from '@azure/cosmos';
+{%- endif %}
+{%- if cookiecutter.cloud_service == 'GCP Cloud Function' %}
+import { Firestore } from '@google-cloud/firestore';
+{%- endif %}
 import { {{cookiecutter.project_class_name}}Repository } from '@repositories';
 import { {{cookiecutter.project_class_name}}Controller } from '@controllers';
 import { {{cookiecutter.project_class_name}}Service, SchemaValidator } from '@services';
 import { env } from '@models';
-
+{% if cookiecutter.cloud_service == 'Azure Function App' %}
 const client = new CosmosClient({
   endpoint: env.COSMOS_DB_URL,
   key: env.COSMOS_DB_KEY,
 });
+{%- endif %}
+{%- if cookiecutter.cloud_service == 'GCP Cloud Function' %}
+const client = new Firestore({
+  projectId: env.GCP_PROJECT_ID,
+  databaseId: env.FIRESTORE_DATABASE,
+});
+{%- endif %}
 
 export const container = new Container({ skipBaseClassChecks: true });
 container.bind<SchemaValidator>(SchemaValidator).to(SchemaValidator);
 container.bind<{{cookiecutter.project_class_name}}Controller>({{cookiecutter.project_class_name}}Controller).to({{cookiecutter.project_class_name}}Controller);
 container.bind<{{cookiecutter.project_class_name}}Service>({{cookiecutter.project_class_name}}Service).to({{cookiecutter.project_class_name}}Service);
 container.bind<{{cookiecutter.project_class_name}}Repository>({{cookiecutter.project_class_name}}Repository).to({{cookiecutter.project_class_name}}Repository);
+{% if cookiecutter.cloud_service == 'Azure Function App' -%}
 container.bind<CosmosClient>(CosmosClient).toConstantValue(client);
+{%- endif %}
+{%- if cookiecutter.cloud_service == 'GCP Cloud Function' %}
+container.bind<Firestore>(Firestore).toConstantValue(client);
+{%- endif %}
 
 export default container;

--- a/typescript/{{cookiecutter.project_class_name}}/controllers/__tests__/{{cookiecutter.project_lower_camel_name}}.controller.test.ts
+++ b/typescript/{{cookiecutter.project_class_name}}/controllers/__tests__/{{cookiecutter.project_lower_camel_name}}.controller.test.ts
@@ -1,5 +1,12 @@
+{% if cookiecutter.cloud_service == 'Azure Function App' -%}
 process.env.COSMOS_DB_URL = 'https://cosmos-mock.documents.azure.com:443/';
 process.env.COSMOS_DB_KEY = 'mock-cosmos-key';
+{%- endif %}
+{%- if cookiecutter.cloud_service == 'GCP Cloud Function' %}
+process.env.GCP_PROJECT_ID = 'mock-gcp-project';
+process.env.FIRESTORE_DATABASE = '(default)';
+process.env.FIRESTORE_COLLECTION = '{{cookiecutter.project_endpoint}}';
+{%- endif %}
 
 import { {{cookiecutter.project_class_name}}Controller } from '@controllers';
 import { {{cookiecutter.project_class_name}}Service } from '@services';

--- a/typescript/{{cookiecutter.project_class_name}}/main.ts
+++ b/typescript/{{cookiecutter.project_class_name}}/main.ts
@@ -1,0 +1,72 @@
+import * as ff from '@google-cloud/functions-framework';
+import { {{cookiecutter.project_class_name}}Controller } from '@controllers';
+import { container } from '@config/inversity.config';
+import { {{cookiecutter.project_class_name}} } from '@models';
+import { detectError } from '@utils';
+
+const ENDPOINT = '{{cookiecutter.project_endpoint}}';
+
+/**
+ * Parses the item ID from the request path.
+ * Expected paths: /{endpoint}/{id} or /{endpoint}
+ */
+const parseId = (path: string): string | undefined => {
+  const segments = path.split('/').filter(Boolean);
+  if (segments.length >= 2 && segments[0] === ENDPOINT) {
+    return segments[1];
+  }
+  return undefined;
+};
+
+const jsonResponse = (res: ff.Response, status: number, body: unknown): void => {
+  res.status(status).json(body);
+};
+
+ff.http('api', async (req: ff.Request, res: ff.Response) => {
+  const controller = container.resolve({{cookiecutter.project_class_name}}Controller);
+
+  try {
+    switch (req.method) {
+      case 'GET': {
+        const id = parseId(req.path);
+        if (id) {
+          const result = await controller.get(id);
+          return jsonResponse(res, 200, result);
+        }
+        const results = await controller.list();
+        return jsonResponse(res, 200, results);
+      }
+
+      case 'POST': {
+        const {{cookiecutter.project_lower_camel_name}}: {{cookiecutter.project_class_name}} = req.body as {{cookiecutter.project_class_name}};
+        const created = await controller.post({{cookiecutter.project_lower_camel_name}});
+        return jsonResponse(res, 201, created);
+      }
+
+      case 'PUT':
+      case 'PATCH': {
+        const id = parseId(req.path);
+        const {{cookiecutter.project_lower_camel_name}}: {{cookiecutter.project_class_name}} = req.body as {{cookiecutter.project_class_name}};
+        const updated = await controller.update({ id, ...{{cookiecutter.project_lower_camel_name}} });
+        return jsonResponse(res, 200, updated);
+      }
+
+      case 'DELETE': {
+        const id = parseId(req.path);
+        if (!id) {
+          return jsonResponse(res, 400, { error: 'Missing item ID.' });
+        }
+        await controller.delete(id);
+        return jsonResponse(res, 200, {
+          message: `{{cookiecutter.project_class_name}} with ID ${id} deleted.`,
+        });
+      }
+
+      default:
+        return jsonResponse(res, 405, { error: 'Method not allowed.' });
+    }
+  } catch (error) {
+    const errorResponse = detectError(error);
+    return res.status(errorResponse.status).send(errorResponse.body);
+  }
+});

--- a/typescript/{{cookiecutter.project_class_name}}/package.json
+++ b/typescript/{{cookiecutter.project_class_name}}/package.json
@@ -3,15 +3,31 @@
   "version": "1.0.0",
   "description": "{{cookiecutter.project_description}}",
   "packageManager": "yarn@4.13.0",
+{%- if cookiecutter.cloud_service == 'Azure Function App' %}
   "main": "dist/functions/*.js",
+{%- endif %}
+{%- if cookiecutter.cloud_service == 'GCP Cloud Function' %}
+  "main": "dist/main.js",
+{%- endif %}
   "scripts": {
     "build": "rm -rf dist && tsc && tsc-alias",
+{%- if cookiecutter.cloud_service == 'Azure Function App' %}
     "start": "func start --typescript",
+{%- endif %}
+{%- if cookiecutter.cloud_service == 'GCP Cloud Function' %}
+    "start": "npx functions-framework --target=api --source=dist/",
+{%- endif %}
     "test:unit": "yarn jest --verbose --coverage"
   },
   "dependencies": {
+{%- if cookiecutter.cloud_service == 'Azure Function App' %}
     "@azure/cosmos": "^4.2.0",
     "@azure/functions": "^4.6.0",
+{%- endif %}
+{%- if cookiecutter.cloud_service == 'GCP Cloud Function' %}
+    "@google-cloud/firestore": "^7.11.0",
+    "@google-cloud/functions-framework": "^3.4.5",
+{%- endif %}
     "dotenv": "^17.0.0",
     "inversify": "^6.1.4",
     "reflect-metadata": "^0.2.2",
@@ -21,7 +37,9 @@
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/node": "^24.0.0",
+{%- if cookiecutter.cloud_service == 'Azure Function App' %}
     "azure-functions-core-tools": "^4.x",
+{%- endif %}
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "tsc-alias": "^1.8.10",

--- a/typescript/{{cookiecutter.project_class_name}}/repositories/__tests__/base.repository.test.ts
+++ b/typescript/{{cookiecutter.project_class_name}}/repositories/__tests__/base.repository.test.ts
@@ -1,9 +1,15 @@
 import 'reflect-metadata';
 import { BaseRepository } from '@repositories';
+{% if cookiecutter.cloud_service == 'Azure Function App' -%}
 import { Container } from '@azure/cosmos';
+{%- endif %}
+{%- if cookiecutter.cloud_service == 'GCP Cloud Function' %}
+import { CollectionReference } from '@google-cloud/firestore';
+{%- endif %}
 import { NotFoundError, ProxyError } from '@errors';
 
 
+{% if cookiecutter.cloud_service == 'Azure Function App' -%}
 class MockNotFound extends Error {
     public code: number | undefined;
 
@@ -285,3 +291,209 @@ describe('BaseRepository', () => {
         });
     });
 });
+{%- endif %}
+{%- if cookiecutter.cloud_service == 'GCP Cloud Function' %}
+const mock{{cookiecutter.project_class_name}}Id = '28535ae3-2f1b-4e81-ba13-0f46a0c74ea0';
+const mock{{cookiecutter.project_class_name}}CreateRecord = {
+    id: mock{{cookiecutter.project_class_name}}Id,
+    name: 'mock{{cookiecutter.project_class_name}}1',
+    createdBy: 'mockUser',
+    updatedBy: 'mockUser',
+};
+const mock{{cookiecutter.project_class_name}}Records = [
+    {
+        id: mock{{cookiecutter.project_class_name}}Id,
+        name: 'mock{{cookiecutter.project_class_name}}1',
+        createdBy: 'mockUser',
+        updatedBy: 'mockUser',
+        createdTimestamp: '2024-03-24T00:00:00.000Z',
+        updatedTimestamp: '2024-03-24T00:00:00.000Z',
+        isDeleted: false,
+    },
+    {
+        id: 'cb8b2d40-edcc-4ac7-93ba-207408b23c8a',
+        name: 'mock{{cookiecutter.project_class_name}}2',
+        createdBy: 'mockUser',
+        updatedBy: 'mockUser',
+        createdTimestamp: '2024-03-24T00:00:00.000Z',
+        updatedTimestamp: '2024-03-24T00:00:00.000Z',
+        isDeleted: false,
+    }
+];
+const mock{{cookiecutter.project_class_name}}Update = {
+    id: mock{{cookiecutter.project_class_name}}Id,
+    name: 'mock{{cookiecutter.project_class_name}}1Update',
+};
+const mockDeletedRecord = {
+    id: mock{{cookiecutter.project_class_name}}Id,
+    name: 'mock{{cookiecutter.project_class_name}}1',
+    isDeleted: true,
+};
+
+let mockSet: jest.Mock;
+let mockGet: jest.Mock;
+let mockUpdate: jest.Mock;
+let mockWhere: jest.Mock;
+let mockStream: jest.Mock;
+let mockDoc: jest.Mock;
+let mockCollection: unknown;
+let mockBaseRepository: BaseRepository<any>;
+
+describe('BaseRepository', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+        mockSet = jest.fn().mockResolvedValue(undefined);
+        mockGet = jest.fn();
+        mockUpdate = jest.fn().mockResolvedValue(undefined);
+        mockStream = jest.fn();
+        mockWhere = jest.fn().mockReturnValue({ get: jest.fn() });
+        mockDoc = jest.fn().mockReturnValue({
+            set: mockSet,
+            get: mockGet,
+            update: mockUpdate,
+        });
+        mockCollection = {
+            doc: mockDoc,
+            where: mockWhere,
+        } as unknown as CollectionReference;
+        mockBaseRepository = new BaseRepository(mockCollection as CollectionReference);
+    });
+
+    describe('addRecord', () => {
+        it('should successfully set document in collection', async () => {
+            const result = await mockBaseRepository.addRecord(mock{{cookiecutter.project_class_name}}Records[0]);
+            expect(mockDoc).toHaveBeenCalledWith(mock{{cookiecutter.project_class_name}}Id);
+            expect(mockSet).toHaveBeenCalledWith(mock{{cookiecutter.project_class_name}}Records[0]);
+            expect(result).toEqual(mock{{cookiecutter.project_class_name}}Records[0]);
+        });
+
+        it('should throw proxy error on failure', async () => {
+            mockSet.mockRejectedValueOnce(new Error('mockError'));
+            try {
+                await mockBaseRepository.addRecord(mock{{cookiecutter.project_class_name}}CreateRecord);
+            } catch (error) {
+                expect(error).toBeInstanceOf(ProxyError);
+                expect(error.statusCode).toEqual(502);
+                expect(error.message).toEqual('Error creating item in database.');
+            }
+        });
+    });
+
+    describe('getRecord', () => {
+        it('should successfully get document by id', async () => {
+            mockGet.mockResolvedValue({
+                exists: true,
+                data: () => mock{{cookiecutter.project_class_name}}Records[0],
+            });
+            const result = await mockBaseRepository.getRecord(mock{{cookiecutter.project_class_name}}Id);
+            expect(mockDoc).toHaveBeenCalledWith(mock{{cookiecutter.project_class_name}}Id);
+            expect(result).toEqual(mock{{cookiecutter.project_class_name}}Records[0]);
+        });
+
+        it('should throw not found error when document does not exist', async () => {
+            mockGet.mockResolvedValue({ exists: false });
+            try {
+                await mockBaseRepository.getRecord(mock{{cookiecutter.project_class_name}}Id);
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotFoundError);
+                expect(error.statusCode).toEqual(404);
+            }
+        });
+
+        it('should throw not found error when document is soft deleted', async () => {
+            mockGet.mockResolvedValue({
+                exists: true,
+                data: () => mockDeletedRecord,
+            });
+            try {
+                await mockBaseRepository.getRecord(mock{{cookiecutter.project_class_name}}Id);
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotFoundError);
+                expect(error.statusCode).toEqual(404);
+            }
+        });
+    });
+
+    describe('getRecords', () => {
+        it('should successfully query non-deleted documents', async () => {
+            const mockSnapshot = {
+                docs: mock{{cookiecutter.project_class_name}}Records.map((r) => ({ data: () => r })),
+            };
+            mockWhere.mockReturnValue({ get: jest.fn().mockResolvedValue(mockSnapshot) });
+            const result = await mockBaseRepository.getRecords();
+            expect(mockWhere).toHaveBeenCalledWith('isDeleted', '==', false);
+            expect(result).toEqual(mock{{cookiecutter.project_class_name}}Records);
+        });
+
+        it('should throw proxy error on failure', async () => {
+            mockWhere.mockReturnValue({
+                get: jest.fn().mockRejectedValue(new Error('Unknown error')),
+            });
+            try {
+                await mockBaseRepository.getRecords();
+            } catch (error) {
+                expect(error).toBeInstanceOf(ProxyError);
+                expect(error.statusCode).toEqual(502);
+            }
+        });
+    });
+
+    describe('updateRecord', () => {
+        it('should successfully update document', async () => {
+            jest.spyOn(mockBaseRepository, 'getRecord')
+                .mockResolvedValue(mock{{cookiecutter.project_class_name}}Records[0]);
+            const result = await mockBaseRepository.updateRecord(mock{{cookiecutter.project_class_name}}Update);
+            expect(mockDoc).toHaveBeenCalledWith(mock{{cookiecutter.project_class_name}}Id);
+            expect(mockUpdate).toHaveBeenCalledTimes(1);
+            expect(result.name).toEqual('mock{{cookiecutter.project_class_name}}1Update');
+        });
+
+        it('should throw not found error when record does not exist', async () => {
+            jest.spyOn(mockBaseRepository, 'getRecord')
+                .mockRejectedValue(new NotFoundError('Not found'));
+            try {
+                await mockBaseRepository.updateRecord(mock{{cookiecutter.project_class_name}}Update);
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotFoundError);
+            }
+        });
+    });
+
+    describe('deleteRecord', () => {
+        it('should successfully soft delete document', async () => {
+            mockGet.mockResolvedValue({
+                exists: true,
+                data: () => mock{{cookiecutter.project_class_name}}Records[0],
+            });
+            await mockBaseRepository.deleteRecord(mock{{cookiecutter.project_class_name}}Id);
+            expect(mockDoc).toHaveBeenCalledWith(mock{{cookiecutter.project_class_name}}Id);
+            expect(mockUpdate).toHaveBeenCalledWith(
+                expect.objectContaining({ isDeleted: true })
+            );
+        });
+
+        it('should throw not found error when document does not exist', async () => {
+            mockGet.mockResolvedValue({ exists: false });
+            try {
+                await mockBaseRepository.deleteRecord(mock{{cookiecutter.project_class_name}}Id);
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotFoundError);
+                expect(error.statusCode).toEqual(404);
+            }
+        });
+
+        it('should throw not found error when document is already deleted', async () => {
+            mockGet.mockResolvedValue({
+                exists: true,
+                data: () => mockDeletedRecord,
+            });
+            try {
+                await mockBaseRepository.deleteRecord(mock{{cookiecutter.project_class_name}}Id);
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotFoundError);
+                expect(error.statusCode).toEqual(404);
+            }
+        });
+    });
+});
+{%- endif %}

--- a/typescript/{{cookiecutter.project_class_name}}/repositories/__tests__/{{cookiecutter.project_lower_camel_name}}.repository.test.ts
+++ b/typescript/{{cookiecutter.project_class_name}}/repositories/__tests__/{{cookiecutter.project_lower_camel_name}}.repository.test.ts
@@ -1,10 +1,15 @@
 import "reflect-metadata";
+{% if cookiecutter.cloud_service == 'Azure Function App' -%}
 import { CosmosClient } from "@azure/cosmos";
+{%- endif %}
+{%- if cookiecutter.cloud_service == 'GCP Cloud Function' %}
+import { Firestore } from "@google-cloud/firestore";
+{%- endif %}
 import { {{cookiecutter.project_class_name}}Repository } from "@repositories";
 import { injectable } from "inversify";
 
 let mockResult;
-
+{% if cookiecutter.cloud_service == 'Azure Function App' %}
 @injectable()
 class MockCosmosClient {
     public database = jest.fn().mockImplementation(() => ({
@@ -19,6 +24,21 @@ describe('{{cookiecutter.project_class_name}}Repository', () => {
 
     const mockCosmosClient = new MockCosmosClient() as unknown as CosmosClient;
     const mock{{cookiecutter.project_class_name}}Repository = new {{cookiecutter.project_class_name}}Repository(mockCosmosClient);
+{%- endif %}
+{%- if cookiecutter.cloud_service == 'GCP Cloud Function' %}
+@injectable()
+class MockFirestore {
+    public collection = jest.fn().mockImplementation(() => mockResult);
+}
+
+describe('{{cookiecutter.project_class_name}}Repository', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    const mockFirestore = new MockFirestore() as unknown as Firestore;
+    const mock{{cookiecutter.project_class_name}}Repository = new {{cookiecutter.project_class_name}}Repository(mockFirestore);
+{%- endif %}
     const mock{{cookiecutter.project_class_name}}Id = '28535ae3-2f1b-4e81-ba13-0f46a0c74ea0';
     const mock{{cookiecutter.project_class_name}} = {
         name: 'mock{{cookiecutter.project_class_name}}',

--- a/typescript/{{cookiecutter.project_class_name}}/repositories/base.repository.ts
+++ b/typescript/{{cookiecutter.project_class_name}}/repositories/base.repository.ts
@@ -1,3 +1,4 @@
+{% if cookiecutter.cloud_service == 'Azure Function App' -%}
 import { Container, PatchOperation } from '@azure/cosmos';
 import { ProxyError, NotFoundError } from '@errors';
 import { BaseItemRecord } from '@models';
@@ -85,3 +86,99 @@ export class BaseRepository<T extends BaseItemRecord> {
     }
   };
 }
+{%- endif %}
+{%- if cookiecutter.cloud_service == 'GCP Cloud Function' %}
+import { CollectionReference } from '@google-cloud/firestore';
+import { ProxyError, NotFoundError } from '@errors';
+import { BaseItemRecord } from '@models';
+
+export class BaseRepository<T extends BaseItemRecord> {
+  readonly _collection: CollectionReference;
+
+  constructor(collection: CollectionReference) {
+    this._collection = collection;
+  }
+
+  addRecord = async (item: T): Promise<T> => {
+    try {
+      const docRef = this._collection.doc(item.id);
+      await docRef.set(item);
+      return item;
+    } catch (error) {
+      throw new ProxyError('Error creating item in database.');
+    }
+  };
+
+  getRecord = async (id: string): Promise<T> => {
+    try {
+      const doc = await this._collection.doc(id).get();
+
+      if (!doc.exists) {
+        throw new NotFoundError(`Record not found for ID ${id}.`);
+      }
+
+      const data = doc.data() as T;
+      if (data.isDeleted) {
+        throw new NotFoundError(`Record not found for ID ${id}.`);
+      }
+
+      return data;
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        throw error;
+      }
+      throw new ProxyError('Error retrieving item from database.');
+    }
+  };
+
+  getRecords = async (): Promise<T[]> => {
+    try {
+      const snapshot = await this._collection
+        .where('isDeleted', '==', false)
+        .get();
+
+      return snapshot.docs.map((doc) => doc.data() as T);
+    } catch (error) {
+      throw new ProxyError('Error retrieving items from database.');
+    }
+  };
+
+  updateRecord = async (updates: T): Promise<T> => {
+    try {
+      const currentItem = await this.getRecord(updates.id);
+      const updatedItem = {
+        ...currentItem,
+        ...updates,
+      };
+      const docRef = this._collection.doc(updates.id);
+      await docRef.update(updatedItem);
+      return updatedItem;
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        throw error;
+      }
+      throw new ProxyError(`Error upserting item with id ${updates.id}.`);
+    }
+  };
+
+  deleteRecord = async (id: string): Promise<void> => {
+    try {
+      const doc = await this._collection.doc(id).get();
+
+      if (!doc.exists || (doc.data() as T).isDeleted) {
+        throw new NotFoundError(`Record with id ${id} not found.`);
+      }
+
+      await this._collection.doc(id).update({
+        isDeleted: true,
+        updatedTimestamp: new Date().toISOString(),
+      });
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        throw error;
+      }
+      throw new ProxyError(`Error deleting record with id ${id}.`);
+    }
+  };
+}
+{%- endif %}

--- a/typescript/{{cookiecutter.project_class_name}}/repositories/{{cookiecutter.project_lower_camel_name}}.repository.ts
+++ b/typescript/{{cookiecutter.project_class_name}}/repositories/{{cookiecutter.project_lower_camel_name}}.repository.ts
@@ -1,5 +1,10 @@
 import { inject, injectable } from 'inversify';
+{% if cookiecutter.cloud_service == 'Azure Function App' -%}
 import { CosmosClient } from '@azure/cosmos';
+{%- endif %}
+{%- if cookiecutter.cloud_service == 'GCP Cloud Function' %}
+import { Firestore } from '@google-cloud/firestore';
+{%- endif %}
 import { {{cookiecutter.project_class_name}}ItemRecord } from '@models';
 import { BaseRepository } from './base.repository';
 import 'reflect-metadata';
@@ -7,11 +12,19 @@ import 'reflect-metadata';
 @injectable()
 export class {{cookiecutter.project_class_name}}Repository extends BaseRepository<{{cookiecutter.project_class_name}}ItemRecord> {
   constructor(
+{%- if cookiecutter.cloud_service == 'Azure Function App' %}
     @inject(CosmosClient) client: CosmosClient
   ) {
     const db = client.database('{{cookiecutter.project_endpoint}}s-sql-db');
     const container = db.container('{{cookiecutter.project_endpoint}}s-sql-container');
     super(container);
+{%- endif %}
+{%- if cookiecutter.cloud_service == 'GCP Cloud Function' %}
+    @inject(Firestore) client: Firestore
+  ) {
+    const collection = client.collection('{{cookiecutter.project_endpoint}}');
+    super(collection);
+{%- endif %}
   }
 
   create = async (new{{cookiecutter.project_class_name}}: {{cookiecutter.project_class_name}}ItemRecord): Promise<{{cookiecutter.project_class_name}}ItemRecord> => this.addRecord(new{{cookiecutter.project_class_name}});

--- a/typescript/{{cookiecutter.project_class_name}}/services/__tests__/schemaValidator.service.test.ts
+++ b/typescript/{{cookiecutter.project_class_name}}/services/__tests__/schemaValidator.service.test.ts
@@ -1,5 +1,12 @@
+{% if cookiecutter.cloud_service == 'Azure Function App' -%}
 process.env.COSMOS_DB_URL = 'https://cosmos-mock.documents.azure.com:443/';
 process.env.COSMOS_DB_KEY = 'mock-cosmos-key';
+{%- endif %}
+{%- if cookiecutter.cloud_service == 'GCP Cloud Function' %}
+process.env.GCP_PROJECT_ID = 'mock-gcp-project';
+process.env.FIRESTORE_DATABASE = '(default)';
+process.env.FIRESTORE_COLLECTION = '{{cookiecutter.project_endpoint}}';
+{%- endif %}
 
 import { ValidationError } from '@errors';
 import { BaseSchema, GuidSchema } from '@models';

--- a/typescript/{{cookiecutter.project_class_name}}/services/__tests__/{{cookiecutter.project_lower_camel_name}}.service.test.ts
+++ b/typescript/{{cookiecutter.project_class_name}}/services/__tests__/{{cookiecutter.project_lower_camel_name}}.service.test.ts
@@ -1,5 +1,12 @@
+{% if cookiecutter.cloud_service == 'Azure Function App' -%}
 process.env.COSMOS_DB_URL = 'https://cosmos-mock.documents.azure.com:443/';
 process.env.COSMOS_DB_KEY = 'mock-cosmos-key';
+{%- endif %}
+{%- if cookiecutter.cloud_service == 'GCP Cloud Function' %}
+process.env.GCP_PROJECT_ID = 'mock-gcp-project';
+process.env.FIRESTORE_DATABASE = '(default)';
+process.env.FIRESTORE_COLLECTION = '{{cookiecutter.project_endpoint}}';
+{%- endif %}
 
 import { injectable } from 'inversify';
 import { {{cookiecutter.project_class_name}}Service } from '@services';

--- a/typescript/{{cookiecutter.project_class_name}}/types/models/baseEnv.schema.ts
+++ b/typescript/{{cookiecutter.project_class_name}}/types/models/baseEnv.schema.ts
@@ -1,6 +1,14 @@
 import { z } from 'zod';
-
+{% if cookiecutter.cloud_service == 'Azure Function App' %}
 export const baseEnvSchema = z.object({
     COSMOS_DB_URL: z.string().url(),
     COSMOS_DB_KEY: z.string().min(1),
 });
+{%- endif %}
+{%- if cookiecutter.cloud_service == 'GCP Cloud Function' %}
+export const baseEnvSchema = z.object({
+    GCP_PROJECT_ID: z.string().min(1),
+    FIRESTORE_DATABASE: z.string().default('(default)'),
+    FIRESTORE_COLLECTION: z.string().default('{{cookiecutter.project_endpoint}}'),
+});
+{%- endif %}

--- a/typescript/{{cookiecutter.project_class_name}}/utils/detectError.util.ts
+++ b/typescript/{{cookiecutter.project_class_name}}/utils/detectError.util.ts
@@ -1,15 +1,14 @@
-import { HttpResponseInit } from '@azure/functions';
 import { BaseError } from '../types/errors/base.error';
 
-export const detectError = <T>(error: T) => {
+export const detectError = <T>(error: T): { status: number; body: string } => {
   if (error instanceof BaseError && error.statusCode !== undefined) {
     return {
       status: error.statusCode,
       body: error.message,
-    } as HttpResponseInit;
+    };
   }
   return {
     status: 500,
     body: 'Unknown error occurred.',
-  } as HttpResponseInit;
+  };
 };


### PR DESCRIPTION
## Summary

- Add GCP Cloud Function as a `cloud_service` option for the TypeScript cookiecutter template, using Firestore for data storage
- Implement Jinja2 conditionals across repository, DI config, env schema, package.json, and test files to support both Azure and GCP
- Create `main.ts` entry point using `@google-cloud/functions-framework` with path-based HTTP routing
- Add `post_gen_project.py` hook to clean up cloud-specific files after generation
- Add `AGENTS.md` with comprehensive guidance for AI agents working on this repository

## Changes

### New Files
- `typescript/hooks/post_gen_project.py` — Post-generation cleanup hook (removes Azure files for GCP, GCP files for Azure)
- `typescript/{{cookiecutter.project_class_name}}/main.ts` — GCP Cloud Function entry point with Express-compatible routing
- `AGENTS.md` — AI agent guidance covering project structure, template patterns, and conventions

### Modified Files
- `typescript/cookiecutter.json` — Added "GCP Cloud Function" to cloud_service options
- `typescript/.../repositories/base.repository.ts` — Firestore implementation alongside Cosmos DB
- `typescript/.../repositories/{project}.repository.ts` — Conditional DI for Firestore vs CosmosClient
- `typescript/.../config/inversity.config.ts` — Conditional Firestore client binding
- `typescript/.../types/models/baseEnv.schema.ts` — GCP env vars (GCP_PROJECT_ID, FIRESTORE_DATABASE, FIRESTORE_COLLECTION)
- `typescript/.../package.json` — Conditional deps (@google-cloud/firestore, @google-cloud/functions-framework)
- `typescript/.../utils/detectError.util.ts` — Made cloud-agnostic (removed @azure/functions import)
- Repository and service/controller test files — Conditional env var setup and GCP-specific Firestore mocks
- `.github/workflows/build-typescript-pipeline.yaml` — Added GCP Cloud Function to CI matrix
- `README.md` — Updated TypeScript GCP status from planned to complete

## Test plan

- [x] Generated Azure template compiles and all 44 tests pass
- [x] Generated GCP template compiles and all 43 tests pass
- [ ] CI pipeline runs both Azure and GCP matrix entries successfully
- [ ] Verify post-gen hook correctly removes cloud-specific files for each option

https://claude.ai/code/session_017m4PeJ7CZa1PkB4E6xytyL