### PR TITLE
Update license badge to link to LICENSE file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ![](https://img.shields.io/github/actions/workflow/status/Code-and-Sorts/cookiecutter-api/build-dotnet-pipeline.yaml?branch=main&label=Dotnet-Build&style=for-the-badge)
 ![](https://img.shields.io/github/actions/workflow/status/Code-and-Sorts/cookiecutter-api/build-go-pipeline.yaml?branch=main&label=Go-Build&style=for-the-badge)
 
-![](https://img.shields.io/github/license/Code-and-Sorts/cookiecutter-api?label=License&style=for-the-badge&color=blue)
+[![](https://img.shields.io/badge/License-MIT-blue?style=for-the-badge)](./LICENSE)
 
 [![](https://img.shields.io/badge/made%20using%20cookiecutter-grey?style=for-the-badge&logo=cookiecutter)](https://github.com/cookiecutter/cookiecutter)
 


### PR DESCRIPTION
## Summary
Updated the license badge in the README to use a static MIT badge that links directly to the LICENSE file, replacing the dynamic GitHub license badge.

## Changes
- Replaced the dynamic GitHub license badge (`img.shields.io/github/license/...`) with a static MIT badge (`img.shields.io/badge/License-MIT-blue`)
- Added a hyperlink to the `./LICENSE` file so users can quickly access the full license text
- Maintained consistent badge styling with the `for-the-badge` style parameter

## Details
This change improves user experience by providing a direct link to the license file while making the license type immediately visible in the README. The static badge is also more reliable than the dynamic GitHub API-based badge.

https://claude.ai/code/session_01BNcwdcow5QyFfAt2ZB33eQ